### PR TITLE
Map IIF to a CASE WHEN expression

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -89,6 +89,8 @@ pub fn simplify_impl(expr: Expression) -> (Expression, bool) {
             return (Expression::AddSequence(v), true);
         }
 
+        // No optimizations below this line: simply recursively simplify operands
+
         // Recursively simplify operands
         Expression::FunctionCall { name, args } => {
             let mut args_changed = false;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -86,7 +86,7 @@ pub fn simplify_impl(expr: Expression) -> (Expression, bool) {
             }
             v.push(tree);
             v.reverse();
-            return (Expression::AddSequence(v), true);
+            (Expression::AddSequence(v), true)
         }
 
         // No optimizations below this line: simply recursively simplify operands

--- a/src/to_sql.rs
+++ b/src/to_sql.rs
@@ -200,6 +200,18 @@ impl ToSQL for Expression {
                 when_false.to_sql(out, conf)?;
                 write!(out, " END")
             }
+            Expression::Case { branches, r#else } => {
+                write!(out, "CASE")?;
+                for branch in branches {
+                    write!(out, " WHEN ")?;
+                    branch.cond.to_sql(out, conf)?;
+                    write!(out, " THEN ")?;
+                    branch.then.to_sql(out, conf)?;
+                }
+                write!(out, " ELSE ")?;
+                r#else.to_sql(out, conf)?;
+                write!(out, " END ")
+            }
             Expression::BareFunctionCall(name) => write!(out, " {name} "),
         }
     }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -56,6 +56,13 @@ impl Parenthesize {
     }
 }
 
+/// A WHEN branch for CASE
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct When {
+    pub cond: Box<Expression>,
+    pub then: Box<Expression>,
+}
+
 /// This is the output type of translation: a Codebase AST goes in, a SQL AST
 ///  comes out.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,6 +91,10 @@ pub enum Expression {
         cond: Box<Expression>,
         when_true: Box<Expression>,
         when_false: Box<Expression>,
+    },
+    Case {
+        branches: Vec<When>,
+        r#else: Box<Expression>,
     },
     // used for things like "CURRENT_DATE" which are functions but don't
     //  allow the parentheses.

--- a/src/translate/postgres.rs
+++ b/src/translate/postgres.rs
@@ -236,18 +236,49 @@ pub fn translate_fn_call(
             FieldType::Character(8),
         ),
 
-        // IIF(x, y, z) => Iif expression
+        // Translate nested IIFs to a flat CASE WHEN. This optimization is
+        //  important because some databases (looking at you, SQL Server) have
+        //  a limit how deeply nested control flow like CASE and IIF can go.
+        //
+        // Note that this:
+        //   IIF(cond_a, v1, IIF(cond_b, v2, v3))
+        // is always structurally equivalent to:
+        //   CASE WHEN cond_a THEN v1 WHEN cond_b THEN v2 ELSE v3 END
         F::IIF => {
             // The result type will be the type of the when_true expression
-            let (when_true, ty) = arg(1)??;
-            ok(
-                Expression::Iif {
-                    cond: arg(0)??.0,
-                    when_true,
-                    when_false: arg(2)??.0,
-                },
-                ty,
-            )
+            let (_, ty) = arg(1)??;
+
+            let mut branches = Vec::new();
+            // We have to take ownership of args for the loop to work
+            //TODO(justin): come back and try to rework this
+            let mut inner_args = Vec::from(args);
+
+            // Add this IIF as a When branch. If when_false is an IIF, traverse
+            //  into it and repeat. We'll eventually encounter a when_false that
+            //  is not an IIF: that will become our ELSE value.
+            let r#else = loop {
+                match inner_args.as_slice() {
+                    [cond, when_true, when_false] => {
+                        // Convert this IIF to a WHEN
+                        branches.push(super::When {
+                            cond: cx.translate(&cond)?.0,
+                            then: cx.translate(&when_true)?.0,
+                        });
+
+                        //TODO there's probably a way to work around this clone
+                        let expr: ast::Expression = (**when_false).clone();
+                        if let ast::Expression::FunctionCall { name: F::IIF, args } = expr {
+                            inner_args = args.clone();
+                        } else {
+                            break when_false;
+                        }
+                    }
+                    _ => panic!("IIF should always have three arguments"),
+                }
+            };
+            let (r#else, _) = cx.translate(&r#else)?;
+
+            ok(Expression::Case { branches, r#else }, ty)
         }
         // LEFT(x, n) => SUBSTR(x, 1, n)
         F::LEFT => ok(

--- a/src/translate/postgres.rs
+++ b/src/translate/postgres.rs
@@ -261,8 +261,8 @@ pub fn translate_fn_call(
                     [cond, when_true, when_false] => {
                         // Convert this IIF to a WHEN
                         branches.push(super::When {
-                            cond: cx.translate(&cond)?.0,
-                            then: cx.translate(&when_true)?.0,
+                            cond: cx.translate(cond)?.0,
+                            then: cx.translate(when_true)?.0,
                         });
 
                         //TODO there's probably a way to work around this clone
@@ -276,7 +276,7 @@ pub fn translate_fn_call(
                     _ => panic!("IIF should always have three arguments"),
                 }
             };
-            let (r#else, _) = cx.translate(&r#else)?;
+            let (r#else, _) = cx.translate(r#else)?;
 
             ok(Expression::Case { branches, r#else }, ty)
         }


### PR DESCRIPTION
SQL Server can't handle IIF nested more than 10 levels deep. This PR introduces a CASE WHEN .. END expression and maps IIF to it, including the traversal of nested IIFs.

Note that this:
  `IIF(cond_a, v1, IIF(cond_b, v2, v3))`
is always structurally equivalent to:
  `CASE WHEN cond_a THEN v1 WHEN cond_b THEN v2 ELSE v3 END`
