### PR TITLE
Made leading and trailing digits optional.

### DIFF
--- a/bestiary.md
+++ b/bestiary.md
@@ -3,6 +3,7 @@ This page documents _interesting_ dBase expressions which Codebase permits.
 ## Comments! (plz no)
 `2.0   )) a comment!`
 
+
 Codebase evaluates this to `2.0` because everything after an unmatched close paren is ignored.
 
 Note that this crate produces a parse error instead, see [Known Inconsistencies](known_inconsistencies.md) for more

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -35,7 +35,7 @@ Bool: bool = {
 	r"\.[tT]([rR][uU][eE])?\." => true,
 	r"\.[fF]([aA][lL][sS][eE])?\." => false,
 };
-Num: String = r"[0-9]+(\.[0-9]+)?" => <>.to_string();
+Num: String = r"[0-9]*+(\.[0-9]*)?" => <>.to_string();
 Ident: String = r"[a-zA-Z_][a-zA-Z_0-9]*" => <>.to_string();
 Call: (String, Vec<Box<Expression>>) = <name:Ident> "(" <args:Exprs> ")" => (name, args);
 Field: Box<Expression> = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,10 @@ fn expr_tests() {
         "a+b+c",
         "'hello' + chr(32) + LEFT('world', 3) + 'ld'",
         "a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c+a+b+c",
+        // Parsing of numbers with optional digits before and after decimal
+        ".+.=.", // 0.0 + 0.0 = 0.0
+        "1. + 2 = 3.00",
+        ".1 + 0.2 = 000.3",
     ];
 
     let value_lookup = |field_name: &str| -> Option<evaluate::Value> {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -201,7 +201,7 @@ impl FieldType {
 ///  translator but intercept anything that needs to be handled differently:
 ///
 /// ```rust
-/// # use dbase_expr::{ast, translate::{self, Expression, FieldType, TranslationContext, Error}, codebase_functions::CodebaseFunction,};
+/// # use dbase_expr::{ast, translate::{self, Expression, FieldType, TranslationContext, Error, ExprRef}, codebase_functions::CodebaseFunction,};
 /// struct MyCustomTranslator
 /// {
 ///     my_state: std::collections::HashMap<String, FieldType>,
@@ -238,6 +238,15 @@ impl FieldType {
 ///
 ///         // and delegate the rest...
 ///         translate::postgres::translate_fn_call(name, args, self)
+///     }
+///
+///     fn translate_binary_op(
+///        &self,
+///        l: &ast::Expression,
+///        op: &ast::BinaryOp,
+///        r: &ast::Expression,
+///     ) -> std::result::Result<(ExprRef, FieldType), Error> {
+///         translate::postgres::translate_binary_op(self, l, op, r)
 ///     }
 /// }
 ///


### PR DESCRIPTION
I've built a proper unittest for the digits thing so that `cargo test`
 tells us whether we've failed or not. Note that there is a failing
 unittest due to precision issues with f64; this will be fixed by
 refactoring evaluate to use a decimal type.