### PR TITLE
Simplify grammar

### DIFF
--- a/known_inconsistencies.md
+++ b/known_inconsistencies.md
@@ -7,3 +7,14 @@ Example: `(2.0)) * 3.0`
 Codebase evaluates this expression as `2.0` while this crate errors due to the extra closing paren in the middle of the expression.
 
 While it is possible to extend the grammar to ignore characters after an unmatched closing paren, we feel that this hides bugs rather than exposing them: the author of the expression certainly wanted `6.0` and accidentally inserted an additional closing paren.
+
+
+## Number parsing
+Codebase will parse a number from nothing but a sign (`-` or `+`) or nothing but a decimal place (`.`). So `-` evaluates to negative zero. This causes lots of weirdness (see the [Bestiary](bestiary.md)) including doing the opposite of what you want (`-1` and `--1` both evaluate to negative one, but `---1` is positive one), so we turn this into an error.
+
+This crate has the following rules for number literals
+* May omit leading digits: `TOTAL * .5` is fine
+* May omit decimal point AND trailing digits: `TOTAL * 5` is fine
+* If the decimal is present, there must be trailing digits: `1.` is _not_ fine
+
+Codebase expressions which are not compliant should always result in parse errors.

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -393,8 +393,7 @@ fn eval_function(name: &F, args: &[Value], get: FieldValueGetter) -> Result<Valu
                         let max_len = *len_true.max(len_false); //get the max of the two because the length shouldn't depend on the values
                         let mut str_value = if *cond { str_true } else { str_false }.clone();
                         if str_value.len() < max_len {
-                            str_value
-                                .extend(std::iter::repeat(' ').take(max_len - str_value.len()));
+                            str_value.extend(std::iter::repeat_n(' ', max_len - str_value.len()));
                         }
                         Value::Str(str_value, max_len)
                     }
@@ -671,7 +670,7 @@ mod tests {
     // Asserts if the expression does not produce an error
     fn assert_any_err(expr: &str) {
         if let Ok(v) = eval(expr) {
-            assert!(false, "Expected an error, got {v:?}");
+            panic!("Expected an error, got {v:?}");
         }
     }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -10,13 +10,7 @@ And = Tier<AndOp, Not>;
 Not = TierUnary<NotOp, Relation>;
 Relation = Tier<RelationOp, Add>;
 Add = Tier<AddOp, Factor>;
-Factor = Tier<FactorOp, Sign>;
-// Any number of '-' and '+' can be placed in front of an expression so we need
-//  to recurse right: `--+-(foo)`
-Sign: Box<Expression> = {
-    <op:SignOp> <r:Sign> => Box::new(Expression::UnaryOperator(op, r)),
-    Exp => <>
-};
+Factor = Tier<FactorOp, Exp>;
 Exp = Tier<ExpOp, Term>;
 
 pub Exprs = Comma<Expr>;
@@ -24,8 +18,8 @@ pub Exprs = Comma<Expr>;
 Term: Box<Expression> = {
 	Bool => Box::new(Expression::BoolLiteral(<>)),
 	Num => Box::new(Expression::NumberLiteral(<>)),
-	DoubleQuoteString => Box::new(Expression::DoubleQuoteStringLiteral(<>)),
-	SingleQuoteString => Box::new(Expression::SingleQuoteStringLiteral(<>)),
+	DoubleQuoteString => Box::new(Expression::StringLiteral(<>)),
+	SingleQuoteString => Box::new(Expression::StringLiteral(<>)),
 
 	// ALIAS->FIELD
 	<alias:Ident> "->" <name:Ident> => Box::new(Expression::Field{ alias: Some(alias), name }),
@@ -40,7 +34,7 @@ Bool: bool = {
 	r"\.[tT]([rR][uU][eE])?\." => true,
 	r"\.[fF]([aA][lL][sS][eE])?\." => false,
 };
-Num: String = r"[0-9]*+(\.[0-9]*)?" => <>.to_string();
+Num: String = r"[\-\+]?[0-9]*(\.[0-9]+)?" => <>.to_string();
 Ident: String = r"[a-zA-Z_][a-zA-Z_0-9]*" => <>.to_string();
 Call: (String, Vec<Box<Expression>>) = <name:Ident> "(" <args:Exprs> ")" => (name, args);
 Field: Box<Expression> = {
@@ -86,11 +80,6 @@ OrOp: BinaryOp = {
 
 NotOp: UnaryOp = {
 	r"\.[nN][oO][tT]\." => UnaryOp::Not,
-};
-
-SignOp: UnaryOp = {
-    "+" => UnaryOp::Pos,
-    "-" => UnaryOp::Neg,
 };
 
 // Utility macros

--- a/src/translate/postgres.rs
+++ b/src/translate/postgres.rs
@@ -72,15 +72,7 @@ pub fn translate<C: TranslationContext>(source: &E, cx: &C) -> Result {
                 },
             )
         }
-        E::SingleQuoteStringLiteral(v) => {
-            let v = escape_single_quotes(v);
-            let len = v.len();
-            ok(
-                Expression::SingleQuoteStringLiteral(v),
-                FieldType::Character(len as u32),
-            )
-        }
-        E::DoubleQuoteStringLiteral(v) => {
+        E::StringLiteral(v) => {
             let v = escape_single_quotes(v);
             let len = v.len();
             ok(
@@ -106,12 +98,6 @@ pub fn translate<C: TranslationContext>(source: &E, cx: &C) -> Result {
                 Expression::UnaryOperator(UnaryOp::Not, translate(r, cx)?.0),
                 FieldType::Logical,
             ),
-            ast::UnaryOp::Neg => {
-                let r = translate(r, cx)?;
-                ok(Expression::UnaryOperator(UnaryOp::Neg, r.0), r.1)
-            }
-            // Pos does nothing, just passes its argument through
-            ast::UnaryOp::Pos => translate(r, cx),
         },
         E::BinaryOperator(l, op, r) => {
             // Add, Sub are ambiguous: could be numeric, concat, or days (for dates)


### PR DESCRIPTION
* Removes single vs double quoted strings from the AST (they're both still parsed)
* `-` and `+` as unary operators (now they're just optional prefixes on numbers)
* Numbers can omit digits _before_ the decimal, but if the decimal point is present there must subsequent digits

All tests passing except precision.