### PR TITLE
small cleanup from learning rust idioms

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -520,7 +520,7 @@ fn eval_function(
                 }
 
                 if len <= dec + 1 {
-                    dec = (len.saturating_sub(2)).max(0); //to allow space for the '.', something like 2,1 doesn't make sense since there would be no space for the leading 0 so codebase just removes the dec
+                    dec = len.saturating_sub(2); //to allow space for the '.', something like 2,1 doesn't make sense since there would be no space for the leading 0 so codebase just removes the dec
                 }
 
                 let fmt = format!("{:width$.prec$}", n, width = len, prec = dec);

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -290,11 +290,7 @@ impl<'input> Lexer<'input> {
     /// Consumes the first token and returns whether its type is equal to `[ty]`
     pub fn consume(&mut self, ty: TokenType) -> Result<bool, Error> {
         let tok = self.next_token()?;
-        Ok(if let Some(tok) = tok {
-            tok.ty == ty
-        } else {
-            false
-        })
+        Ok(tok.is_some_and(|tok| tok.ty == ty))
     }
 
     /// Look at the next token without actually consuming it

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -481,6 +481,8 @@ fn parse_binary_op<'input>(
                 ..
             })) = lexer.peek_token()
             {
+                // We've already popped the function name [name_token], now remove the left paren
+                lexer.next_token()?;
                 parse_fn_call(lexer, tree, scratch, &tok, depth.inc()?)
             } else {
                 // otherwise a field reference
@@ -644,11 +646,7 @@ fn parse_fn_call<'input>(
     //  stack frames are also using this buffer so it might not be empty.
     let scratch_start = scratch.len();
 
-    // We've already popped the function name [name_token], so expect a ParenLeft
-    if !lexer.consume(TokenType::ParenLeft)? {
-        return Err(Error::UnexpectedEof);
-    }
-
+    // We've already removed the function name and left paren, so jump right into the argument list
     // Zero or more arguments
     let mut first = true;
     loop {
@@ -661,7 +659,7 @@ fn parse_fn_call<'input>(
         }
 
         // If not closing the list, it must be another argument.
-        // If this isn't the first argument, expect a comment
+        // If this isn't the first argument, expect a comma
         if !first {
             if !lexer.consume(TokenType::Comma)? {
                 return Err(Error::UnexpectedToken(t));

--- a/src/translate/postgres.rs
+++ b/src/translate/postgres.rs
@@ -842,7 +842,7 @@ pub fn get_str_fn_args<'a>(
     let mut dec: usize = dec.min(15);
 
     if len <= dec + 1 {
-        dec = (len.saturating_sub(2)).max(0); //to allow space for the '.', something like 2,1 doesn't make sense since there would be no space for the leading 0 so codebase just removes the dec
+        dec = len.saturating_sub(2); //to allow space for the '.', something like 2,1 doesn't make sense since there would be no space for the leading 0 so codebase just removes the dec
     }
 
     let fmt = if dec > 0 {


### PR DESCRIPTION
1. Use `is_some_and` to simplify the logic in consume()
2. Remove unnecessary (and incorrect) error handling for the left paren on a function call.
3. Remove unnecessary calls to max() on uints