### PR TITLE
Allow backwards LTE and GTE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,6 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
- "regex",
  "serde",
  "strum",
  "strum_macros",

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -330,7 +330,6 @@ impl<'input> Lexer<'input> {
             b',' => tok!(Comma),
             b'/' => tok!(ForwardSlash),
             b'$' => tok!(Dollar),
-            b'=' => tok!(Equals),
             b'^' => tok!(DoubleAsterisk),
             b'#' => tok!(NotEquals),
 
@@ -368,6 +367,17 @@ impl<'input> Lexer<'input> {
                     tok!(GTE)
                 } else {
                     tok!(GT)
+                }
+            }
+            // Codebase actually allows LTE and GTE to be written "backwards",
+            //  e.g. `12 =< 13` or `12 => 13`
+            b'=' => {
+                if self.consume1(b'>') {
+                    tok!(GTE)
+                } else if self.consume1(b'<') {
+                    tok!(LTE)
+                } else {
+                    tok!(Equals)
                 }
             }
 
@@ -687,5 +697,13 @@ mod tests {
         let source = r#"[ ' " ]"#;
         let mut lexer = Lexer::new(source.as_bytes());
         assert_toks!(lexer, StringBracketQuote);
+    }
+
+    #[test]
+    fn backwards_operators() {
+        let mut lexer = Lexer::new("12 =< 13".as_bytes());
+        assert_toks!(lexer, Number, LTE, Number);
+        let mut lexer = Lexer::new("12 => 13".as_bytes());
+        assert_toks!(lexer, Number, GTE, Number);
     }
 }


### PR DESCRIPTION
Turns out Codebase accepts `=>` and `=<` for GTE and LTE. This slightly expands the lexer to allow them as well.

Also updates Cargo.lock to remove stale depenendency on regex crate.